### PR TITLE
Detect page object on the Url or Commands keys

### DIFF
--- a/lib/core/api.js
+++ b/lib/core/api.js
@@ -474,7 +474,7 @@ module.exports = new (function() {
   }
 
   function useEnhancedModel(pageFnOrObject) {
-    return typeof pageFnOrObject == 'object' && (pageFnOrObject.elements || pageFnOrObject.sections);
+    return typeof pageFnOrObject == 'object' && (pageFnOrObject.url || pageFnOrObject.elements || pageFnOrObject.sections || pageFnOrObject.commands);
   }
 
   /**


### PR DESCRIPTION
At the moment, the docs have a page object with only the `url` key, but this code only instantiates a proper page object if the `elements` or `sections` key is present. This looks for `url` or `commands` to be present as well, fixing #570

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with addressing it quicker.

- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet
- [ ] If it's a new feature explain why do you think it's necessary
- [ ] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [ ] Do not include changes that are not related to the issue at hand
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [ ] Add unit tests