### PR TITLE
Added workerIndex property to ChildProcess

### DIFF
--- a/lib/runner/cli/child-process.js
+++ b/lib/runner/cli/child-process.js
@@ -4,12 +4,13 @@ var events = require('events');
 
 var Logger = require('../../util/logger.js');
 
-function ChildProcess(environment, index, env_output, settings, args) {
+function ChildProcess(environment, index, workerIndex, env_output, settings, args) {
   events.EventEmitter.call(this);
 
   this.env_output = env_output || [];
   this.mainModule = process.mainModule.filename;
   this.index = index;
+  this.workerIndex = workerIndex;
   this.itemKey = this.getChildProcessEnvKey(environment);
   this.startDelay = settings.parallel_process_delay || ChildProcess.defaultStartDelay;
   this.environment = environment;
@@ -46,6 +47,7 @@ ChildProcess.prototype.run = function(colors, done) {
 
   setTimeout(function() {
     env.__NIGHTWATCH_PARALLEL_MODE = 1;
+    env.__NIGHTWATCH_PARALLEL_WORKER_INDEX = self.workerIndex;
     env.__NIGHTWATCH_ENV = self.environment;
     env.__NIGHTWATCH_ENV_KEY = self.itemKey;
     env.__NIGHTWATCH_ENV_LABEL = self.env_itemKey;

--- a/lib/runner/cli/clirunner.js
+++ b/lib/runner/cli/clirunner.js
@@ -810,8 +810,10 @@ CliRunner.prototype = {
       self.childProcessOutput[environment] = [];
       var childArgs = args.slice();
       childArgs.push('--env', environment);
+      var workerIndex = index % envs.length;
 
-      var child = new ChildProcess(environment, index, self.childProcessOutput[environment], self.settings, childArgs);
+      var child = new ChildProcess(environment, index, workerIndex,
+          self.childProcessOutput[environment], self.settings, childArgs);
       child.setLabel(environment + ' environment');
       self.runningProcesses[child.itemKey] = child;
       self.runningProcesses[child.itemKey].run(availColors, function(output, exitCode) {
@@ -870,7 +872,7 @@ CliRunner.prototype = {
       }
 
       var remaining = modulePaths.length;
-      Utils.processAsyncQueue(workerCount, modulePaths, function(modulePath, index, next) {
+      Utils.processAsyncQueue(workerCount, modulePaths, function(modulePath, index, workerIndex, next) {
         var outputLabel = Utils.getModuleKey(modulePath, self.settings.src_folders, modulePaths);
         var childOutput = self.childProcessOutput[outputLabel] = [];
 
@@ -881,7 +883,7 @@ CliRunner.prototype = {
         var settings = clone(self.settings);
         settings.output = settings.output && settings.detailed_output;
 
-        var child = new ChildProcess(outputLabel, index, childOutput, settings, childArgs);
+        var child = new ChildProcess(outputLabel, index, workerIndex, childOutput, settings, childArgs);
         child.setLabel(outputLabel);
         child.on('result', function(childResult) {
           switch (childResult.type) {

--- a/lib/util/utils.js
+++ b/lib/util/utils.js
@@ -145,11 +145,17 @@ Util.processAsyncQueue = function(concurrency, files, cb) {
     queue.push(item);
   };
 
-  var workers = 0;
+  var workerQueue = [];
+  for (var wi = 0; wi < maxWorkers; wi++) {
+    workerQueue.push(wi);
+  }
+
   var index = 0;
-  var next = function() {
-    workers -= 1;
-    process();
+  var next = function(workerIndex) {
+      return function() {
+        workerQueue.push(workerIndex);
+        process();
+      };
   };
 
   for (var i = 0; i < files.length; i++) {
@@ -157,12 +163,12 @@ Util.processAsyncQueue = function(concurrency, files, cb) {
   }
 
   var process = function() {
-    while (workers < maxWorkers) {
-      workers += 1;
+    while (workerQueue.length > 0) {
+      var workerIndex = workerQueue.shift();
 
       if (queue.length) {
         var item = queue.shift();
-        cb(item, index++, next);
+        cb(item, index++, workerIndex, next(workerIndex));
       }
     }
   };


### PR DESCRIPTION
workerIndex is an index that can be used to
uniquely identify workers.

If you run tests with 4 workers, worker indices
will be 0, 1, 2 and 3.

Thanks in advance for your contribution. Please follow the below steps in submitting a pull request, as it will help us with addressing it quicker.

- [ ] Create a new branch from master (e.g. `features/my-new-feature` or `issue/123-my-bugfix`)
- [ ] If you're fixing a bug also create an issue if one doesn't exist yet
- [ ] If it's a new feature explain why do you think it's necessary
- [ ] If your change include drastic or low level changes please discuss them to make sure they will be accepted and what the impact will be
- [ ] If your change is based on existing functionality please consider refactoring first. Pull requests that duplicate code will not make it in very quick, if at all.
- [ ] Do not include changes that are not related to the issue at hand
- [ ] Follow the same coding style with regards to spaces, semicolons, variable naming etc.
- [ ] Add unit tests